### PR TITLE
Fixed path resolution for deep network train files.

### DIFF
--- a/src/openMVG/features/image_describer_deep.hpp
+++ b/src/openMVG/features/image_describer_deep.hpp
@@ -11,6 +11,7 @@
 #include <limits>
 #include <numeric>
 #include <cereal/cereal.hpp>
+#include <third_party/stlplus3/filesystemSimplified/file_system.hpp>
 
 #include "openMVG/features/deep/src/DeepClassifier.hpp"
 #include "openMVG/features/deep/src/DeepClassifierTHNets.hpp"
@@ -41,7 +42,7 @@ struct DEEPParams
 {
   // Because of the absurdities of C++ not having an enum -> string generator
   const std::string DeepDescriptorFileName(EDEEP_DESCRIPTOR descriptor) {
-    const std::string& modelDir = "/home/nomoko/Downloads/openMVGMatt/src/openMVG/features/deep/networks/";
+    const std::string& modelDir = stlplus::folder_part(__FILE__) + "/deep/networks/";
     switch (descriptor) {
       case SIAM_2_STREAM_DESC_NOTRE_DAME: {
         const std::string modelStr(modelDir + "siam2stream/siam2stream_desc_notredame.bin");


### PR DESCRIPTION
So last time i came cross this i thought of a cmake definition based solution, requesting the absolute path from the user and propagating it into a temporary build file to be read from source at compile time. Its transparent and error prone to path changes.
But since these binaries are part of the source tree a much simpler solution is to just use the preprocessor macro for the current compile directory. When you add dynamic retrieval for these train files though, you might consider the upper approach.
